### PR TITLE
Fix dropping of host session when one player leaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.vscode
+*.o
+*.log
+mitm
+moc_*
+.qmake*
+Makefile

--- a/mitm.h
+++ b/mitm.h
@@ -130,7 +130,7 @@ struct Server {
 
   uint32_t version;
   QPointer<QTcpServer> server;
-  QList<QPointer<QTcpSocket> > sockets;
+  QMap<uint, QPointer<QTcpSocket>> sockets;
 };
 
 enum ClientState {
@@ -170,7 +170,8 @@ private slots:
   quint16 findFreePort();
 
 private:
-  void sendMODE(QTcpSocket *sock, uint disconnecting_client = 0);
+  void sendMODE(QTcpSocket *sock, bool has_disconnected = false);
+  uint nextClientNum(QMap<uint, QPointer<QTcpSocket>> *sockets);
 
   QPointer<QTcpServer> m_server;
   QList<Server> m_servers;

--- a/mitm.h
+++ b/mitm.h
@@ -170,7 +170,7 @@ private slots:
   quint16 findFreePort();
 
 private:
-  void sendMODE(QTcpSocket *sock);
+  void sendMODE(QTcpSocket *sock, uint disconnecting_client = 0);
 
   QPointer<QTcpServer> m_server;
   QList<Server> m_servers;


### PR DESCRIPTION
The old code didn't properly handle the client_num of the connected clients and assumed a perfectly ordered and never disconnecting player base.

This PR fixes this by using a hashmap and altering some behavior of the server, to properly handle disconnecting players and reusing their old slots when new players arrive.

This fixes #6.